### PR TITLE
handle when data has no labels

### DIFF
--- a/Ruby/Google Vault/GoogleXmlObjects.rb_
+++ b/Ruby/Google Vault/GoogleXmlObjects.rb_
@@ -138,7 +138,14 @@ class GoogleXmlDocument
 	end
 
 	def labels
-		return find_tag("Labels").get_labels
+		# In some instances XML file may no longer have this so we
+		# need to handle situation where it is not present.
+		found_tag = find_tag("Labels")
+		if found_tag.nil?
+			return ["NO_LABELS"]
+		else
+			return found_tag.get_labels
+		end
 	end
 
 	def external_file_name


### PR DESCRIPTION
Update to **GoogleXmlDocument** due to XML data possibly lacking `Labels` node now.  This is the first time I've had this reported to me I believe so it may be a change to the XML format exported by Google?  Now if there is no labels, it returns `NO_LABELS` so that later logic expecting it to be there can keep working.

```ruby
def labels
	return find_tag("Labels").get_labels
end
```

to this

```ruby
def labels
	# In some instances XML file may no longer have this so we
	# need to handle situation where it is not present.
	found_tag = find_tag("Labels")
	if found_tag.nil?
		return ["NO_LABELS"]
	else
		return found_tag.get_labels
	end
end
```